### PR TITLE
Make it possible to move origin error again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,12 @@ impl<E> Error<E> {
     pub fn original_error(&self) -> &E {
         &self.original_error
     }
+    
+    /// Move the original error out.
+    #[inline]
+    pub fn into_origin(self) -> E {
+        self.original_error
+    }
 
     /// Transforms this Error<OldError> into Error<NewError>. This isn't implemented as an Into or
     /// From implementation because it would conflict with the blanket implementations in stdlib.


### PR DESCRIPTION
Sometimes we may want to move the original error out again.

Currently we have to use `original_error().clone()` to get an owned error. But clone may be expensive or even impossible sometimes, so we need a method to just move it out.