### PR TITLE
make code more compact

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -6,31 +6,33 @@ extern crate test;
 extern crate throw;
 
 use test::Bencher;
+use throw::Result;
+use std::result::{Result as StdResult};
 
 #[inline(never)]
-fn gives_throw_ok() -> Result<&'static str, throw::Error<&'static str>> {
+fn gives_throw_ok() -> Result<&'static str, &'static str> {
     test::black_box(Ok("ok"))
 }
 
 #[inline(never)]
-fn gives_ok() -> Result<&'static str, &'static str> {
+fn gives_ok() -> StdResult<&'static str, &'static str> {
     test::black_box(Ok("ok"))
 }
 
 #[inline(never)]
-fn throws_up_ok() -> Result<&'static str, throw::Error<&'static str>> {
+fn throws_up_ok() -> Result<&'static str, &'static str> {
     let ok_msg = test::black_box(up!(gives_throw_ok()));
     Ok(ok_msg)
 }
 
 #[inline(never)]
-fn throws_throw_ok() -> Result<&'static str, throw::Error<&'static str>> {
+fn throws_throw_ok() -> Result<&'static str, &'static str> {
     let ok_msg = test::black_box(throw!(gives_ok()));
     Ok(ok_msg)
 }
 
 #[inline(never)]
-fn throws_try_ok() -> Result<&'static str, &'static str> {
+fn throws_try_ok() -> StdResult<&'static str, &'static str> {
     let ok_msg = test::black_box(try!(gives_ok()));
     Ok(ok_msg)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,8 +171,11 @@ impl ErrorPoint {
     }
 
     #[doc(hidden)]
-    pub fn __construct(line: u32, column: u32, module_path: &'static str, file: &'static str)
-            -> ErrorPoint {
+    pub fn __construct(line: u32,
+                       column: u32,
+                       module_path: &'static str,
+                       file: &'static str)
+                       -> ErrorPoint {
         ErrorPoint {
             line: line,
             column: column,
@@ -186,15 +189,15 @@ impl ErrorPoint {
 /// which the error was propagated.
 pub struct Error<E> {
     points: Vec<ErrorPoint>,
-    original_error: E,
+    err: E,
 }
 
 impl<E> Error<E> {
     /// Creates a new Error with no ErrorPoints
-    pub fn new(error: E) -> Error<E> {
+    pub fn new(err: E) -> Error<E> {
         Error {
             points: Vec::new(),
-            original_error: error,
+            err: err,
         }
     }
 
@@ -213,44 +216,60 @@ impl<E> Error<E> {
 
     /// Gets the original error which this Error was constructed with.
     #[inline]
-    pub fn original_error(&self) -> &E {
-        &self.original_error
+    pub fn err(&self) -> &E {
+        &self.err
     }
-    
-    /// Move the original error out.
+
+    /// transform the inner err to expected err.
     #[inline]
-    pub fn into_origin(self) -> E {
-        self.original_error
+    pub fn into_err<N>(self) -> N
+        where E: Into<N>
+    {
+        self.err.into()
     }
 
     /// Transforms this Error<OldError> into Error<NewError>. This isn't implemented as an Into or
     /// From implementation because it would conflict with the blanket implementations in stdlib.
-    pub fn transform<NE>(self) -> Error<NE> where E: Into<NE> {
+    pub fn transform<NE>(self) -> Error<NE>
+        where E: Into<NE>
+    {
         Error {
             points: self.points,
-            original_error: self.original_error.into(),
+            err: self.err.into(),
         }
     }
 }
 
-impl<E> fmt::Display for Error<E> where E: fmt::Display {
+impl<E> fmt::Display for Error<E>
+    where E: fmt::Display
+{
     fn fmt(&self, fmt: &mut fmt::Formatter) -> std::result::Result<(), fmt::Error> {
-        try!(write!(fmt, "Error: {}", self.original_error));
+        try!(write!(fmt, "Error: {}", self.err));
         for point in self.points.iter().rev() {
-            try!(write!(fmt, "\n\tat {}:{} in {} ({})", point.line(), point.column(),
-                point.module_path(), point.file()));
+            try!(write!(fmt,
+                        "\n\tat {}:{} in {} ({})",
+                        point.line(),
+                        point.column(),
+                        point.module_path(),
+                        point.file()));
         }
 
         Ok(())
     }
 }
 
-impl<E> fmt::Debug for Error<E> where E: fmt::Debug {
+impl<E> fmt::Debug for Error<E>
+    where E: fmt::Debug
+{
     fn fmt(&self, fmt: &mut fmt::Formatter) -> std::result::Result<(), fmt::Error> {
-        try!(write!(fmt, "Error: {:?}", self.original_error));
+        try!(write!(fmt, "Error: {:?}", self.err));
         for point in self.points.iter().rev() {
-            try!(write!(fmt, "\n\tat {}:{} in {} ({})", point.line(), point.column(),
-                point.module_path(), point.file()));
+            try!(write!(fmt,
+                        "\n\tat {}:{} in {} ({})",
+                        point.line(),
+                        point.column(),
+                        point.module_path(),
+                        point.file()));
         }
 
         Ok(())
@@ -264,17 +283,24 @@ macro_rules! up {
             Ok(v) => v,
             Err(e) => {
                 // re-assignment for a better error message if up!() is used incorrectly
-                let mut e: $crate::Error<_> = e.transform();
-                e.__push_point($crate::ErrorPoint::__construct(
-                    line!(),
-                    column!(),
-                    module_path!(),
-                    file!(),
-                ));
-                return Err(e);
+                return as_err!(e.transform());
             },
         }
     );
+}
+
+#[macro_export]
+macro_rules! as_err {
+    ($e:expr) => ({
+        let mut e = $e;
+        e.__push_point($crate::ErrorPoint::__construct(
+            line!(),
+            column!(),
+            module_path!(),
+            file!(),
+        ));
+        Err(e)
+    })
 }
 
 #[macro_export]
@@ -290,13 +316,6 @@ macro_rules! throw {
 #[macro_export]
 macro_rules! throw_new {
     ($e:expr) => ({
-        let mut e: $crate::Error<_> = $crate::Error::new($e.into());
-        e.__push_point($crate::ErrorPoint::__construct(
-            line!(),
-            column!(),
-            module_path!(),
-            file!(),
-        ));
-        return Err(e);
+        return as_err!($crate::Error::new($e.into()));
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,9 +215,23 @@ impl<E> Error<E> {
     }
 
     /// Gets the original error which this Error was constructed with.
+    #[deprecated="use `err` instead."]
+    #[inline]
+    pub fn original_error(&self) -> &E {
+        self.err()
+    }
+
+    /// Gets the original error which this Error was constructed with.
     #[inline]
     pub fn err(&self) -> &E {
         &self.err
+    }
+
+    /// Move the original error out.
+    #[deprecated="use `into_err` instead."]
+    #[inline]
+    pub fn into_origin(self) -> E {
+        self.into_err()
     }
 
     /// transform the inner err to expected err.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -53,9 +53,11 @@ fn test_static_message() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_multiple_throws() {
     let error = throw3().unwrap_err();
     assert_eq!(error.err(), &());
+    assert_eq!(error.err(), error.original_error());
     assert_eq!(format!("{:?}", error), "Error: ()\
     \n\tat 21:4 in lib (tests/lib.rs)\
     \n\tat 16:4 in lib (tests/lib.rs)\

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,43 +1,45 @@
 #[macro_use]
 extern crate throw;
 
+use throw::Result;
 
-fn throw_static_message() -> Result<(), throw::Error<&'static str>> {
+
+fn throw_static_message() -> Result<(), &'static str> {
     throw_new!("hi");
 }
 
-fn throw1() -> Result<(), throw::Error<()>> {
+fn throw1() -> Result<(), ()> {
     throw_new!(());
 }
 
-fn throw2() -> Result<(), throw::Error<()>> {
+fn throw2() -> Result<(), ()> {
     up!(throw1());
     Ok(())
 }
 
-fn throw3() -> Result<(), throw::Error<()>> {
+fn throw3() -> Result<(), ()> {
     up!(throw2());
     Ok(())
 }
 
-fn gives_ok() -> Result<&'static str, throw::Error<&'static str>> {
+fn gives_ok() -> Result<&'static str, &'static str> {
     Ok("ok")
 }
 
-fn throws_ok() -> Result<&'static str, throw::Error<&'static str>> {
+fn throws_ok() -> Result<&'static str, &'static str> {
     let ok_msg = up!(gives_ok());
     Ok(ok_msg)
 }
 
 mod mod_test {
-    use throw;
+    use throw::Result;
 
-    pub fn throws() -> Result<(), throw::Error<&'static str>> {
+    pub fn throws() -> Result<(), &'static str> {
         throw_new!("ahhhh");
     }
 }
 
-fn throws_into() -> Result<(), throw::Error<String>> {
+fn throws_into() -> Result<(), String> {
     throw!(Err("some static string"));
     Ok(())
 }
@@ -45,18 +47,19 @@ fn throws_into() -> Result<(), throw::Error<String>> {
 #[test]
 fn test_static_message() {
     let error = throw_static_message().unwrap_err();
-    assert_eq!(*error.original_error(), "hi");
-    assert_eq!(error.to_string(), "Error: hi\n\tat 6:4 in lib (tests/lib.rs)");
+    assert_eq!(*error.err(), "hi");
+    assert_eq!(error.to_string(), "Error: hi\n\tat 8:4 in lib (tests/lib.rs)");
+    assert_eq!("hi".to_owned(), error.into_err::<String>());
 }
 
 #[test]
 fn test_multiple_throws() {
     let error = throw3().unwrap_err();
-    assert_eq!(error.original_error(), &());
+    assert_eq!(error.err(), &());
     assert_eq!(format!("{:?}", error), "Error: ()\
-    \n\tat 19:4 in lib (tests/lib.rs)\
-    \n\tat 14:4 in lib (tests/lib.rs)\
-    \n\tat 10:4 in lib (tests/lib.rs)");
+    \n\tat 21:4 in lib (tests/lib.rs)\
+    \n\tat 16:4 in lib (tests/lib.rs)\
+    \n\tat 12:4 in lib (tests/lib.rs)");
 }
 
 #[test]
@@ -69,12 +72,12 @@ fn test_returns_ok() {
 fn test_mod_throw() {
     let error = mod_test::throws().unwrap_err();
     assert_eq!(error.to_string(), "Error: ahhhh\
-    \n\tat 36:8 in lib::mod_test (tests/lib.rs)");
+    \n\tat 38:8 in lib::mod_test (tests/lib.rs)");
 }
 
 #[test]
 fn test_throws_into() {
     let error = throws_into().unwrap_err();
     assert_eq!(error.to_string(), "Error: some static string\
-    \n\tat 41:4 in lib (tests/lib.rs)")
+    \n\tat 43:4 in lib (tests/lib.rs)")
 }


### PR DESCRIPTION
- reformat code (cargo fmt)
- use throw::Result instead
- rename origin_error to err
