### PR TITLE
Fixed bug in throw! macro which was causing a compiler error when cal…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -629,7 +629,7 @@ macro_rules! throw {
      ($e:expr, $($key:expr => $value:expr),+) => ({
          match $e {
             Ok(v) => v,
-            Err(e) => throw_new!(e, $($key, $value)*),
+            Err(e) => throw_new!(e, $($key => $value)*),
         }
     })
 }

--- a/tests/exceptions_work.rs
+++ b/tests/exceptions_work.rs
@@ -72,6 +72,11 @@ fn throws_into() -> Result<(), String> {
     Ok(())
 }
 
+fn throws_into_key_value() -> Result<(), String> {
+    throw!(Err("some static string"), "key" => "value");
+    Ok(())
+}
+
 #[test]
 fn test_static_message() {
     let error = throw_static_message().unwrap_err();
@@ -150,6 +155,17 @@ fn test_throws_into() {
     let error = throws_into().unwrap_err();
     assert_matches!(
         r#"Error: some static string
+    at [0-9]+:[0-9] in exceptions_work \([a-z/._-]+\)"#,
+        error
+    )
+}
+
+#[test]
+fn test_throws_into_key_value() {
+    let error = throws_into_key_value().unwrap_err();
+    assert_matches!(
+        r#"Error: some static string
+    key: value
     at [0-9]+:[0-9] in exceptions_work \([a-z/._-]+\)"#,
         error
     )


### PR DESCRIPTION
…led with key/value pairs.

Added test case for throw! with a key/value pair.

The throw! macro was causing a confusing error when called with key/value pairs, since it expanded to an incorrect call to throw_new!. This just fixes that problem and adds a test case.