### PR TITLE
Implement std::error::Error for throw::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,8 +590,15 @@ where
 
 impl<E> std::error::Error for Error<E>
 where
-    E: fmt::Display + fmt::Debug
+    E: std::error::Error
 {
+    fn description(&self) -> &str {
+        self.error().description()
+    }
+
+    fn cause(&self) -> Option<&std::error::Error> {
+        Some(self.error())
+    }
 }
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,6 +588,12 @@ where
     }
 }
 
+impl<E> std::error::Error for Error<E>
+where
+    E: fmt::Display + fmt::Debug
+{
+}
+
 #[macro_export]
 macro_rules! up {
     ($e:expr) => (

--- a/tests/exceptions_work.rs
+++ b/tests/exceptions_work.rs
@@ -93,6 +93,34 @@ fn throws_into_multiple_key_value_pairs() -> Result<(), String> {
     Ok(())
 }
 
+#[derive(Debug)]
+struct CustomError(String);
+
+impl std::fmt::Display for CustomError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "CustomError: {}", self.0)
+    }
+}
+
+impl std::error::Error for CustomError {
+    fn description(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+fn throws_error_with_description() -> Result<(), CustomError> {
+    throw!(Err(CustomError("err".to_owned())));
+    Ok(())
+}
+
+fn throws_error_with_description_and_key_value_pairs() -> Result<(), CustomError> {
+    throw!(
+        Err(CustomError("err".to_owned())),
+        "key" => "value"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_static_message() {
     let error = throw_static_message().unwrap_err();
@@ -218,4 +246,31 @@ fn test_throws_into_multiple_key_value_pairs() {
     at [0-9]+:[0-9] in exceptions_work \([a-z/._-]+\)"#,
         error
     )
+}
+
+#[test]
+fn test_error_description() {
+    use std::error::Error;
+
+    let error = throws_error_with_description().unwrap_err();
+    assert_eq!(error.description(), "err");
+}
+
+#[test]
+fn test_error_description_with_key_value_pairs() {
+    use std::error::Error;
+
+    let error = throws_error_with_description_and_key_value_pairs().unwrap_err();
+    assert_eq!(error.description(), "err");
+}
+
+#[test]
+fn test_error_with_cause() {
+    use std::error::Error;
+
+    let error = throws_error_with_description().unwrap_err();
+    assert_eq!(
+        format!("{}", error.cause().unwrap()),
+        "CustomError: err"
+    );
 }


### PR DESCRIPTION
Fix for #7.